### PR TITLE
docker 19.03 이후 버전의 nvidia-docker command 수정

### DIFF
--- a/docker.mldev.base.jpt.gpu/Makefile
+++ b/docker.mldev.base.jpt.gpu/Makefile
@@ -36,7 +36,7 @@
 # PROCESSOR=CPU
 
 # <GPU>
-GPU?=0
+GPU?='"device=0"'
 #DOCKER=NV_GPU=$(GPU) nvidia-docker
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook

--- a/docker.mldev.base.jpt.gpu/Makefile
+++ b/docker.mldev.base.jpt.gpu/Makefile
@@ -37,7 +37,7 @@
 
 # <GPU>
 GPU?=0
-DOCKER=NV_GPU=$(GPU) nvidia-docker
+#DOCKER=NV_GPU=$(GPU) nvidia-docker
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook
 # JUPYTER=lab
@@ -73,7 +73,7 @@ pull: ## 레지스트리에서 이미지를 받아옵니다.
 	docker pull $(ARG_IMAGE_NAME)
 
 run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -86,7 +86,7 @@ run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
 		$(ARG_IMAGE_NAME)
 
 runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터랙티브 모드)
-	$(DOCKER) run -it --restart=unless-stopped \
+	docker run -it --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -100,7 +100,7 @@ runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터�
         bash
 
 runf: ## 도커 컨테이너를 실행합니다. (고정 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \

--- a/docker.mldev.base.ssh.gpu/Makefile
+++ b/docker.mldev.base.ssh.gpu/Makefile
@@ -36,7 +36,7 @@
 # PROCESSOR=CPU
 
 # <GPU>
-GPU?=0
+GPU?='"device=0"'
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook
 # JUPYTER=lab

--- a/docker.mldev.base.ssh.gpu/Makefile
+++ b/docker.mldev.base.ssh.gpu/Makefile
@@ -37,7 +37,6 @@
 
 # <GPU>
 GPU?=0
-DOCKER=NV_GPU=$(GPU) nvidia-docker
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook
 # JUPYTER=lab
@@ -70,7 +69,7 @@ pull: ## 레지스트리에서 이미지를 받아옵니다.
 	docker pull $(ARG_IMAGE_NAME)
 
 run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -82,7 +81,7 @@ run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
 		$(ARG_IMAGE_NAME)
 
 runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터랙티브 모드)
-	$(DOCKER) run -it --restart=unless-stopped \
+	docker run -it --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -95,7 +94,7 @@ runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터�
 		bash
 
 runf: ## 도커 컨테이너를 실행합니다. (고정 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \

--- a/docker.mldev.spch.ssh.gpu/Makefile
+++ b/docker.mldev.spch.ssh.gpu/Makefile
@@ -36,7 +36,7 @@
 # PROCESSOR=CPU
 
 # <GPU>
-GPU?=0
+GPU?='"device=0"'
 #DOCKER=NV_GPU=$(GPU) nvidia-docker
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook

--- a/docker.mldev.spch.ssh.gpu/Makefile
+++ b/docker.mldev.spch.ssh.gpu/Makefile
@@ -37,7 +37,7 @@
 
 # <GPU>
 GPU?=0
-DOCKER=NV_GPU=$(GPU) nvidia-docker
+#DOCKER=NV_GPU=$(GPU) nvidia-docker
 #-------------------------------------------------------------------------------
 # JUPYTER=notebook
 # JUPYTER=lab
@@ -70,7 +70,7 @@ pull: ## 레지스트리에서 이미지를 받아옵니다.
 	docker pull $(ARG_IMAGE_NAME)
 
 run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -83,7 +83,7 @@ run: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결)
 		$(ARG_IMAGE_NAME)
 
 runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터랙티브 모드)
-	$(DOCKER) run -it --restart=unless-stopped \
+	docker run -it --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \
@@ -97,7 +97,7 @@ runi: ## 도커 컨테이너를 실행합니다. (랜덤 포트 연결. 인터�
 		bash
 
 runf: ## 도커 컨테이너를 실행합니다. (고정 포트 연결)
-	$(DOCKER) run -d --restart=unless-stopped \
+	docker run -d --gpus $(GPU) --restart=unless-stopped \
 		--name $(ARG_CONTAINER_NAME) \
 		--ipc=host \
 		-h $(ARG_CONTAINER_HOSTNAME) \


### PR DESCRIPTION
Docker version 19.03 이후 부터는 NVIDIA GPUs가 docker runtime 내부에서 지원되기 때문에 nvidia-docker 명령어는 사용하지 않도록 수정하였습니다.

Note that with the release of Docker 19.03, usage of nvidia-docker2 packages are deprecated since NVIDIA GPUs are now natively supported as devices in the Docker runtime.

참고: https://github.com/NVIDIA/nvidia-docker